### PR TITLE
plugin-gateway: also allow other characters than [a-zA-Z0-9_]

### DIFF
--- a/opnsense_checkmk_agent.py
+++ b/opnsense_checkmk_agent.py
@@ -720,7 +720,7 @@ class checkmk_checker(object):
             try:
                 _sock.connect(_path)
                 _data = _sock.recv(1024).decode("utf-8").strip()
-                _name, _rtt, _rttsd, _loss = re.findall("(\w+)\s(\d+)\s(\d+)\s(\d+)$",_data)[0]
+                _name, _rtt, _rttsd, _loss = re.findall("(\S+)\s(\d+)\s(\d+)\s(\d+)$",_data)[0]
                 assert _name.strip() == gateway
                 return int(_rtt)/1_000_000.0,int(_rttsd)/1_000_000.0, int(_loss)
             except:


### PR DESCRIPTION
 w in the regular expression only allows [a-zA-Z0-9_] but not e.g. -