### PR TITLE
Fix ifconfig parsing error

### DIFF
--- a/opnsense_checkmk_agent.py
+++ b/opnsense_checkmk_agent.py
@@ -576,7 +576,7 @@ class checkmk_checker(object):
             #if _interface.startswith("vmx"): ## vmware fix 10GBe (as OS Support)
             #    _interface_dict["speed"] = "10000"
             _interface_dict["systime"] = _now
-            for _key, _val in re.findall("^\s*(\w+)[:\s=]+(.*?)$",_data,re.MULTILINE):
+            for _key, _val in re.findall("^\s*(\w+)[:\s=]+(.*?)(?!\n\t\t)$",_data,re.DOTALL | re.MULTILINE):
                 if _key == "description":
                     _interface_dict["interface_name"] = re.sub("_\((lan|wan|opt\d+)\)$","",_val.strip().replace(" ","_"))
                 if _key == "groups":


### PR DESCRIPTION
The output from [ifconfig](https://github.com/bashclub/checkmk-opnsense-agent/blob/7f7d90fab4d4ddadcd32ce1435af7a89427fe8e7/opnsense_checkmk_agent.py#L567) interprets the `lagg options` flags parameter as the interfaces flags. This leads to ignoring the lagg interfaces.

```
lagg0: flags=8943<UP,BROADCAST,RUNNING,PROMISC,SIMPLEX,MULTICAST> metric 0 mtu 1500
        options=4800028<VLAN_MTU,JUMBO_MTU,NOMAP>
        capabilities=4f507bb<RXCSUM,TXCSUM,VLAN_MTU,VLAN_HWTAGGING,JUMBO_MTU,VLAN_HWCSUM,TSO4,TSO6,LRO,VLAN_HWFILTER,VLAN_HWTSO,NETMAP,RXCSUM_IPV6,TXCSUM_IPV6,NOMAP>
        ether f4:90:ea:01:25:ee
        inet6 fe80::f690:eaff:fe01:25ee%lagg0 prefixlen 64 scopeid 0x11
        laggproto lacp lagghash l2
        lagg options:
                flags=0<>
                flowid_shift: 16
        lagg statistics:
                active ports: 2
                flapping: 0
        lag id: [(8000,F4-90-EA-01-25-EE,0A28,0000,0000),
                 (1000,AA-AA-AA-AA-AA-AA,0023,0000,0000)]
        laggport: ice0 flags=1c<ACTIVE,COLLECTING,DISTRIBUTING> state=3d<ACTIVITY,AGGREGATION,SYNC,COLLECTING,DISTRIBUTING>
                [(8000,F4-90-EA-01-25-EE,0A28,8000,0005),
                 (1000,AA-AA-AA-AA-AA-AA,0023,8000,0021)]
        laggport: ice1 flags=1c<ACTIVE,COLLECTING,DISTRIBUTING> state=3d<ACTIVITY,AGGREGATION,SYNC,COLLECTING,DISTRIBUTING>
                [(8000,F4-90-EA-01-25-EE,0A28,8000,0006),
                 (1000,AA-AA-AA-AA-AA-AA,0023,8000,0041)]
        groups: lagg
        media: Ethernet autoselect
        status: active
        supported media:
                media autoselect
        nd6 options=23<PERFORMNUD,ACCEPT_RTADV,AUTO_LINKLOCAL>
```