### PR TITLE
Fix OpenVPN client traffic and maxclients calculation

### DIFF
--- a/opnsense_checkmk_agent.py
+++ b/opnsense_checkmk_agent.py
@@ -945,7 +945,7 @@ class checkmk_checker(object):
                         _ret.append('2 "OpenVPN Connection: {name}" connections_ssl_vpn=0;;|expiredays={expiredays}|if_in_octets=0|if_out_octets=0 Server down Port:/{protocol} {expiredate}'.format(**_server))
                         continue
                 else:
-                    if not _server.get("maxclients"):
+                    if not _server.get("maxclients") and _server.get("tunnel_network"):
                         _max_clients = ipaddress.IPv4Network(_server.get("tunnel_network")).num_addresses -2
                         if _server.get("topology_subnet") != "yes" and _server.get("topology") != "subnet":
                             _max_clients = max(1,int(_max_clients/4)) ## p2p


### PR DESCRIPTION
OpenVPN client connections simply fail with: 

```
ipaddress.AddressValueError: Expected 4 octets in 'None'
Traceback (most recent call last):
  File "/usr/local/etc/rc.syshook.d/start/99-checkmk_agent", line 325, in do_checks
    _lines += getattr(self,_check)()
              ^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/etc/rc.syshook.d/start/99-checkmk_agent", line 948, in checklocal_openvpn
    _max_clients = ipaddress.IPv4Network(_server.get("tunnel_network")).num_addresses -2
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/ipaddress.py", line 1539, in __init__
    self.network_address = IPv4Address(addr)
                           ^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/ipaddress.py", line 1319, in __init__
    self._ip = self._ip_int_from_string(addr_str)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/ipaddress.py", line 1206, in _ip_int_from_string
    raise AddressValueError("Expected 4 octets in %r" % ip_str)
```

Client-mode should be handled in same way as "p2p connections".


-    Treat OpenVPN client entries as p2p for traffic retrieval
-    Guard maxclients derivation behind tunnel_network presence